### PR TITLE
Update setup.py to require python>=3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.12.8',            # Specify the Python versions you support
+    python_requires='>=3.8',            # Specify the Python versions you support
 )


### PR DESCRIPTION
Currently, there are no significant dependency differences between `main` and `json-based`, so requiring Python version as old as 3.8 should work for both.