### PR TITLE
Json based

### DIFF
--- a/liger/pipelines/tpot.py
+++ b/liger/pipelines/tpot.py
@@ -6,7 +6,6 @@ import json
 from random import randint
 from datetime import datetime, timezone
 import numpy as np
-import pandas as pd
 from ..dataset import Dataset
 from ..training_testing import kfold_predict
 from tpot import TPOTClassifier, TPOTRegressor
@@ -176,6 +175,7 @@ class TPOTPipeline:
             pipeline_parameters.get("n_splits"),
             self.dataset.X.shape[0],
         )
+        early_stop = tpot_parameters.get("early_stop")
 
         if self.regression:
             self.tpot = TPOTRegressor(
@@ -185,6 +185,7 @@ class TPOTPipeline:
                 verbosity=2,
                 random_state=tpot_random_state,
                 max_time_mins=max_time_mins,
+                early_stop=early_stop,
                 warm_start=True,
             )
         else:
@@ -195,6 +196,7 @@ class TPOTPipeline:
                 verbosity=2,
                 random_state=tpot_random_state,
                 max_time_mins=max_time_mins,
+                early_stop=early_stop,
                 warm_start=True,
             )
 

--- a/liger/pipelines/tpot.py
+++ b/liger/pipelines/tpot.py
@@ -403,7 +403,7 @@ class TPOTPipeline:
             "tpot_parameters": tpot_parameters,
             "tpot_attributes": tpot_attributes,
         }
-        with open(self.output_dir + str(self.id) + "output.json", "w") as f:
+        with open(self.output_dir + str(self.id) + ".json", "w") as f:
             json.dump(pipeline_dict, f, indent=4, default=TPOTPipeline.dict_everything)
 
 

--- a/liger/pipelines/tpot.py
+++ b/liger/pipelines/tpot.py
@@ -1,7 +1,9 @@
+from typing import Any
 import sys
 from os import makedirs, remove
 from os.path import isdir, isfile
-from time import sleep
+import json
+from random import randint
 from datetime import datetime, timezone
 import numpy as np
 import pandas as pd
@@ -21,82 +23,194 @@ PICKLE = "Pickles/"
 IN_PROGRESS = "InProgress/"
 PERFORMANCE = "performance.csv"
 RATINGS = "ratings.csv"
+TPOT_ATTRS = [
+    "fitted_pipeline_",
+    "pareto_front_fitted_pipelines_",
+    "evaluated_individuals_",
+]
+REG_CLASS_OVERLAP = {
+    "sklearn.preprocessing.Binarizer",
+    "sklearn.decomposition.FastICA",
+    "sklearn.cluster.FeatureAgglomeration",
+    "sklearn.preprocessing.MaxAbsScaler",
+    "sklearn.preprocessing.MinMaxScaler",
+    "sklearn.preprocessing.Normalizer",
+    "sklearn.kernel_approximation.Nystroem",
+    "sklearn.decomposition.PCA",
+    "sklearn.preprocessing.PolynomialFeatures",
+    "sklearn.kernel_approximation.RBFSampler",
+    "sklearn.preprocessing.RobustScaler",
+    "sklearn.preprocessing.StandardScaler",
+    "tpot.builtins.ZeroCount",
+    "tpot.builtins.OneHotEncoder",
+    "sklearn.feature_selection.SelectFwe",
+    "sklearn.feature_selection.SelectPercentile",
+    "sklearn.feature_selection.VarianceThreshold",
+    "sklearn.feature_selection.SelectFromModel",
+}
+PIPELINE_PARAM_KEYS = {
+    "config_name",
+    "data_name",
+    "regression",
+    "target_gens",
+    "eval_random_states",
+    "n_splits",
+    "slurm_id",
+    "id",
+}
+TPOT_PARAM_KEYS = {
+    "population_size",
+    "offspring_size",
+    "generations",
+    "mutation_rate",
+    "crossover_rate",
+    "scoring",
+    "cv",
+    "subsample",
+    "n_jobs",
+    "max_time_mins",
+    "max_eval_time_mins",
+    "periodic_checkpoint_folder",
+    "early_stop",
+    "config_dict",
+    "template",
+    "warm_start",
+    "memory",
+    "use_dask",
+    "verbosity",
+    "disable_update_check",
+    "random_state",
+    "log_file",
+}
+TPOT_ATTR_KEYS = {
+    "tree_structure",
+    "evaluated_individuals_",
+    "fitted_pipeline_"
+    "log_file_",
+    "pareto_front_fitted_pipelines_",
+}
 
 
 class TPOTPipeline:
 
     def __init__(
         self,
+        config_file: str,
         data_file: str,
-        regression: bool,
-        target_gens: int,
-        pop_size: int,
-        tpot_random_state: int,
-        eval_random_states: list[int],
-        no_trees: bool = False,
-        no_xg: bool = False,
-        cutoff_mins: int | None = None,
+        target_gens: int | None = None,
+        population_size: int | None = None,
+        tpot_random_state: int | None = None,
+        eval_random_states: list[int] | None = None,
+        max_time_mins: int | None = None,
         n_splits: int | None = None,
         slurm_id: int | None = None,
-    ):
+        id: str | None = None,
+    ) -> None:
+        self.config_name = TPOTPipeline.get_filename(config_file)
         self.dataset = Dataset.from_csv(data_file)
-        self.data_name = TPOTPipeline.get_data_name(data_file)
-        self.target_gens = target_gens
+        self.data_name = TPOTPipeline.get_filename(data_file)
         self.complete_gens = 0
-        self.pop_size = pop_size
-        self.tpot_random_state = tpot_random_state
-        self.eval_random_states = eval_random_states
-        self.no_trees = no_trees
-        self.no_xg = no_xg
-        self.cutoff_mins = cutoff_mins
         self.slurm_id = slurm_id
 
-        if not regression and self.dataset.y.dtype == np.float64:
-            print("WARNING: Float data detected, using regression instead of classification.", flush=True)
-            regression = True
-        self.regression = regression
-        if n_splits:
-            self.n_splits = n_splits
-        else:
-            self.n_splits = self.dataset.X.shape[0]
+        # Load config file
+        with open(config_file) as f:
+            config = dict(json.load(f))
+        pipeline_parameters = config.get("pipeline_parameters")
+        if pipeline_parameters is None:
+            pipeline_parameters = {}
+        tpot_parameters = config.get("tpot_parameters")
+        if tpot_parameters is None:
+            tpot_parameters = {}
 
-        # NOTE: Whether or not regression was set to true by detection of floats,
-        #       regression in the ID will be what the arguments specified (reg/clas).
-        #       This is necessary for run_tpot_pipeline.py to find the right pickle file.
-        self.id = TPOTPipeline.get_id(target_gens, pop_size, tpot_random_state, regression, no_trees, no_xg)
-        self.tpot = self.tpot_init()
+        # Record start time
+        dt = datetime.now(timezone.utc)
+        start_time = dt.strftime("%Y-%m-%d_%H-%M-%S.%f")
+
+        # Require regression if there's float data
+        if self.dataset.y.dtype == np.float64:
+            require_regression = True
+        else:
+            require_regression = False
+
+        # Set and vet the TPOT config dictionary; determine if regression will be used
+        config_dict = tpot_parameters.get("config_dict")
+        if isinstance(config_dict, dict):
+            self.regression = self.check_config_dict(config_dict, require_regression)
+        elif config_dict is None:
+            config_dict = regressor_config_dict
+            self.regression = True
+        else:
+            raise TypeError(f"\"config_dict\" field of {self.config_name} is not None or of type dict")
+
+        # Set parameters
+        self.target_gens = TPOTPipeline.use_first(
+            target_gens,
+            pipeline_parameters.get("target_gens"),
+            10,
+        )
+        population_size = int(TPOTPipeline.use_first(
+            population_size,
+            tpot_parameters.get("population_size"),
+            100,
+        ))
+        tpot_random_state = TPOTPipeline.use_first(
+            tpot_random_state,
+            tpot_parameters.get("random_state"),
+            randint(0, 9999999999),
+        )
+        self.eval_random_states = TPOTPipeline.use_first(
+            eval_random_states,
+            pipeline_parameters.get("eval_random_states"),
+            [0],
+        )
+        self.id = TPOTPipeline.use_first(
+            id,
+            pipeline_parameters.get("id"),
+            start_time,
+        )
+        max_time_mins = TPOTPipeline.use_first(
+            max_time_mins,
+            tpot_parameters.get("max_time_mins"),
+        )
+        self.n_splits = TPOTPipeline.use_first(
+            n_splits,
+            pipeline_parameters.get("n_splits"),
+            self.dataset.X.shape[0],
+        )
+
+        if self.regression:
+            self.tpot = TPOTRegressor(
+                config_dict=config_dict,
+                generations=1,
+                population_size=population_size,
+                verbosity=2,
+                random_state=tpot_random_state,
+                max_time_mins=max_time_mins,
+                warm_start=True,
+            )
+        else:
+            self.tpot = TPOTClassifier(
+                config_dict=config_dict,
+                generations=1,
+                population_size=population_size,
+                verbosity=2,
+                random_state=tpot_random_state,
+                max_time_mins=max_time_mins,
+                warm_start=True,
+            )
+
 
         self.output_dir = OUTPUT + self.data_name + "/"
         self.pickle_dir = PICKLE + self.data_name + "/"
         self.inprogress_dir = IN_PROGRESS + self.data_name + "/"
 
-
-    @classmethod
-    def get_data_name(cls, data_file: str) -> str:
-        return data_file.rsplit("/")[-1].split(".")[0]
-
-
-    @classmethod
-    def get_id(cls, target_gens: int, pop_size: int, tpot_random_state: int, regression: bool, no_trees: bool, no_xg: bool) -> str:
-        return "gens_" + str(target_gens) + "_popsize_" + \
-            str(pop_size) + "_tpotrs_" + str(tpot_random_state) + \
-                "_reg" if regression else "_clas" + \
-                    "_notrees" if no_trees else "" + "_noxg" if no_xg else ""
-
-
-    @classmethod
-    def find_pickle(cls, data_name: str, id: str) -> str | None:
-        pickle_name = PICKLE + data_name + "/" + id + ".pkl"
-        if not isdir(PICKLE):
-            return None
-        if isfile(pickle_name):
-            return pickle_name
-        return None
+        print("ID =", self.id, flush=True)
+        print("TPOT random state =", tpot_random_state, flush=True)
 
 
     @classmethod
     def from_pickle(cls, pickle_file: str) -> 'TPOTPipeline':
-        with open(pickle_file, 'rb') as f:
+        with open(pickle_file, "rb") as f:
             return TPOTPipeline.from_bytes(f.read())
 
 
@@ -110,6 +224,65 @@ class TPOTPipeline:
             statistics=dict,
         )
         return dill.loads(serialization)
+
+
+    @staticmethod
+    def use_first(*args) -> Any:
+        """Return the first arg which is not None."""
+        for arg in args:
+            if arg is not None:
+                return arg
+        return None
+
+
+    @staticmethod
+    def get_filename(data_file: str) -> str:
+        return data_file.rsplit("/")[-1].split(".")[0]
+
+
+    @staticmethod
+    def get_id(target_gens: int, pop_size: int, tpot_random_state: int, regression: bool, no_trees: bool, no_xg: bool) -> str:
+        return "gens_" + str(target_gens) + "_popsize_" + \
+            str(pop_size) + "_tpotrs_" + str(tpot_random_state) + \
+                "_reg" if regression else "_clas" + \
+                    "_notrees" if no_trees else "" + "_noxg" if no_xg else ""
+
+
+    @staticmethod
+    def find_pickle(data_name: str, id: str) -> str | None:
+        pickle_name = PICKLE + data_name + "/" + id + ".pkl"
+        if not isdir(PICKLE):
+            return None
+        if isfile(pickle_name):
+            return pickle_name
+        return None
+
+
+    @staticmethod
+    def dict_everything(objec) -> str | None:
+        if hasattr(objec, "__dict__"):
+            return json.dumps(objec.__dict__, indent=4, default=TPOTPipeline.dict_everything)
+        else:
+            return None
+
+
+    def check_config_dict(self, config_dict: dict, require_regression: bool) -> bool:
+        reg_key = False
+        clas_key = False
+        for key in config_dict.keys():
+            if key in REG_CLASS_OVERLAP:
+                continue
+            if key in regressor_config_dict:
+                reg_key = True
+            elif key in classifier_config_dict:
+                clas_key = True
+            else:
+                raise KeyError(f"{key} is not a valid sklearn model")
+        if clas_key and require_regression:
+            raise TypeError(f"float values found in {self.data_name}, but {self.config_name} contains classifiers")
+        if reg_key and clas_key:
+            raise ValueError(f"{self.config_name} contains regressors and classifiers")
+        return not clas_key
 
 
     def to_pickle(self) -> None:
@@ -186,64 +359,52 @@ class TPOTPipeline:
         remove(self.inprogress_dir + self.id + ".txt")
 
 
-    def tpot_init(self):
-        if self.regression:
-            custom_config = regressor_config_dict
-        else:
-            custom_config = classifier_config_dict
-        if self.no_trees:
-            custom_config = {key: value for key, value in custom_config.items() if 'RandomForest' not in key and 'Tree' not in key}
-        if self.no_xg:
-            custom_config = {key: value for key, value in custom_config.items() if 'XG' not in key}
-        if self.regression:
-            tpot = TPOTRegressor(
-                config_dict=custom_config,
-                generations=1,
-                population_size=self.pop_size,
-                verbosity=2,
-                random_state=self.tpot_random_state,
-                max_time_mins=self.cutoff_mins,
-                warm_start=True,
-            )
-        else:
-            tpot = TPOTClassifier(
-                config_dict=custom_config,
-                generations=1,
-                population_size=self.pop_size,
-                verbosity=2,
-                random_state=self.tpot_random_state,
-                max_time_mins=self.cutoff_mins,
-                warm_start=True,
-            )
-        return tpot
+    # def evaluate(self) -> None:
+    #     training_score = self.tpot.score(self.dataset.X, self.dataset.y)
+    #     for eval_random_state in self.eval_random_states:
+    #         kfold_predictions, kfold_r2 = self.tpot_test(eval_random_state)
+    #         self.wait_for_free_csv()
+    #         with open(self.output_dir + "unsafe.txt", 'w') as _:
+    #             pass
+    #         ratings = pd.read_csv(self.output_dir + RATINGS)
+    #         ratings.insert(ratings.shape[1], self.id, kfold_predictions, True)
+    #         ratings.to_csv(self.output_dir + RATINGS, index=False)
+    #         performances = pd.read_csv(self.output_dir + PERFORMANCE)
+    #         performances.loc[performances.shape[0]] = pd.Series(
+    #             {
+    #                 'regression': self.regression,
+    #                 'n_gens': self.target_gens,
+    #                 'pop_size': self.pop_size,
+    #                 'trees_allowed': not self.no_trees,
+    #                 'tpot_random_state': self.tpot_random_state,
+    #                 'eval_random_state': eval_random_state,
+    #                 'training_score': training_score,
+    #                 'n_splits': self.n_splits,
+    #                 'KFold_R2': kfold_r2
+    #             }
+    #         )
+    #         performances.to_csv(self.output_dir + PERFORMANCE, index=False)
+    #         remove(self.output_dir + "unsafe.txt")
 
 
     def evaluate(self) -> None:
         training_score = self.tpot.score(self.dataset.X, self.dataset.y)
+        ratings = {}
+        scores = {}
         for eval_random_state in self.eval_random_states:
             kfold_predictions, kfold_r2 = self.tpot_test(eval_random_state)
-            self.wait_for_free_csv()
-            with open(self.output_dir + "unsafe.txt", 'w') as _:
-                pass
-            ratings = pd.read_csv(self.output_dir + RATINGS)
-            ratings.insert(ratings.shape[1], self.id, kfold_predictions, True)
-            ratings.to_csv(self.output_dir + RATINGS, index=False)
-            performances = pd.read_csv(self.output_dir + PERFORMANCE)
-            performances.loc[performances.shape[0]] = pd.Series(
-                {
-                    'regression': self.regression,
-                    'n_gens': self.target_gens,
-                    'pop_size': self.pop_size,
-                    'trees_allowed': not self.no_trees,
-                    'tpot_random_state': self.tpot_random_state,
-                    'eval_random_state': eval_random_state,
-                    'training_score': training_score,
-                    'n_splits': self.n_splits,
-                    'KFold_R2': kfold_r2
-                }
-            )
-            performances.to_csv(self.output_dir + PERFORMANCE, index=False)
-            remove(self.output_dir + "unsafe.txt")
+            ratings[eval_random_state] = kfold_predictions
+            scores[eval_random_state] = kfold_r2
+        pipeline_parameters = {key: value for key, value in self.__dict__.items() if key in PIPELINE_PARAM_KEYS}
+        tpot_parameters = {key: value for key, value in self.tpot.__dict__.items() if key in TPOT_PARAM_KEYS}
+        tpot_attributes = {key: value for key, value in self.tpot.__dict__.items() if key in TPOT_ATTR_KEYS}
+        pipeline_dict = {
+            "pipeline_parameters": pipeline_parameters,
+            "tpot_parameters": tpot_parameters,
+            "tpot_attributes": tpot_attributes,
+        }
+        with open(self.output_dir + str(self.id) + "output.json", "w") as f:
+            json.dump(pipeline_dict, f, default=TPOTPipeline.dict_everything)
 
 
     def tpot_test(self, eval_random_state: int) -> tuple[np.ndarray, float]:
@@ -252,14 +413,4 @@ class TPOTPipeline:
         kfold_predictions = kfold_predict(self.tpot.fitted_pipeline_, kfold, self.dataset)
         kfold_r2 = float(r2_score(kfold_predictions, self.dataset.y))
         return kfold_predictions, kfold_r2
-
-
-    def wait_for_free_csv(self) -> None:
-        loop_count = 0
-        while isfile(self.output_dir + "unsafe.txt"):
-            sleep(0.1)
-            loop_count += 1
-            if loop_count > 100:
-                print("WARNING: Output csv possibly stuck marked as not safe for writing.")
-                return
 

--- a/liger/pipelines/tpot.py
+++ b/liger/pipelines/tpot.py
@@ -17,7 +17,8 @@ import dill
 from deap import base, creator, gp
 
 
-OUTPUT= "Outputs/TPOT/"
+OUTPUT = "Outputs/"
+EXPORT = "Exports/"
 PICKLE = "Pickles/"
 IN_PROGRESS = "InProgress/"
 TPOT_ATTRS = [
@@ -202,6 +203,7 @@ class TPOTPipeline:
 
 
         self.output_dir = OUTPUT + self.data_name + "/"
+        self.export_dir = EXPORT + self.data_name + "/"
         self.pickle_dir = PICKLE + self.data_name + "/"
         self.inprogress_dir = IN_PROGRESS + self.data_name + "/"
 
@@ -322,7 +324,7 @@ class TPOTPipeline:
             self.tpot.fit(self.dataset.X, self.dataset.y)
             self.complete_gens += 1
         if self.complete_gens >= self.target_gens or "Will end the optimization process." in capture.get_output():
-            self.tpot.export(self.output_dir + self.id + ".py")
+            self.tpot.export(self.export_dir + self.id + ".py")
             self.evaluate()
             self.to_pickle()
             self.not_in_progress()
@@ -335,12 +337,14 @@ class TPOTPipeline:
 
 
     def save_prep(self) -> None:
+        if not isdir(self.output_dir):
+            makedirs(self.output_dir)
+        if not isdir(self.export_dir):
+            makedirs(self.export_dir)
         if not isdir(self.pickle_dir):
             makedirs(self.pickle_dir)
         if not isdir(self.inprogress_dir):
             makedirs(self.inprogress_dir)
-        if not isdir(self.output_dir):
-            makedirs(self.output_dir)
 
 
     def in_progress(self):

--- a/liger/pipelines/tpot.py
+++ b/liger/pipelines/tpot.py
@@ -404,7 +404,7 @@ class TPOTPipeline:
             "tpot_attributes": tpot_attributes,
         }
         with open(self.output_dir + str(self.id) + "output.json", "w") as f:
-            json.dump(pipeline_dict, f, default=TPOTPipeline.dict_everything)
+            json.dump(pipeline_dict, f, indent=4, default=TPOTPipeline.dict_everything)
 
 
     def tpot_test(self, eval_random_state: int) -> tuple[np.ndarray, float]:

--- a/liger/pipelines/tpot.py
+++ b/liger/pipelines/tpot.py
@@ -351,8 +351,7 @@ class TPOTPipeline:
         for eval_random_state in self.eval_random_states:
             kfold_predictions, kfold_r2 = self.tpot_test(eval_random_state)
             scores[eval_random_state] = kfold_r2
-            ratings[eval_random_state] = kfold_predictions
-        print("RATINGS\n", ratings)
+            ratings[eval_random_state] = kfold_predictions.tolist()
         pipeline_parameters = {key: value for key, value in self.__dict__.items() if key in PIPELINE_PARAM_KEYS}
         tpot_parameters = {key: value for key, value in self.tpot.__dict__.items() if key in TPOT_PARAM_KEYS}
         pipeline_attributes = {"kfold_scores": scores, "kfold_ratings": ratings}

--- a/liger/pipelines/tpot.py
+++ b/liger/pipelines/tpot.py
@@ -363,7 +363,7 @@ class TPOTPipeline:
             ratings[eval_random_state] = kfold_predictions.tolist()
         pipeline_parameters = {key: value for key, value in self.__dict__.items() if key in PIPELINE_PARAM_KEYS}
         tpot_parameters = {key: value for key, value in self.tpot.__dict__.items() if key in TPOT_PARAM_KEYS}
-        pipeline_attributes = {"kfold_scores": scores, "kfold_ratings": ratings}
+        pipeline_attributes = {"complete_gens": self.complete_gens, "kfold_scores": scores, "kfold_ratings": ratings}
         tpot_attributes = {key: value for key, value in self.tpot.__dict__.items() if key in TPOT_ATTR_KEYS}
         pipeline_dict = {
             "pipeline_parameters": pipeline_parameters,

--- a/liger/pipelines/tpot.py
+++ b/liger/pipelines/tpot.py
@@ -319,7 +319,7 @@ class TPOTPipeline:
             return
         self.to_pickle()
         self.not_in_progress()
-        print("\nRUN INCOMPLETE")
+        print(f"\nRUN INCOMPLETE WITH ID: {self.id}")
         return
 
 

--- a/liger/pipelines/tpot.py
+++ b/liger/pipelines/tpot.py
@@ -257,8 +257,14 @@ class TPOTPipeline:
 
 
     @staticmethod
-    def dict_everything(objec) -> str | None:
-        if hasattr(objec, "__dict__"):
+    def dict_everything(objec: Any) -> str | None:
+        if isinstance(objec, np.ndarray):
+            objec = objec.tolist()
+            return json.dumps(objec, indent=4, default=TPOTPipeline.dict_everything)
+        elif isinstance(objec, range):
+            objec = [i for i in objec]
+            return json.dumps(objec, indent=4, default=TPOTPipeline.dict_everything)
+        elif hasattr(objec, "__dict__"):
             return json.dumps(objec.__dict__, indent=4, default=TPOTPipeline.dict_everything)
         else:
             return None

--- a/liger/pipelines/tpot.py
+++ b/liger/pipelines/tpot.py
@@ -154,7 +154,7 @@ class TPOTPipeline:
         tpot_random_state = TPOTPipeline.use_first(
             tpot_random_state,
             tpot_parameters.get("random_state"),
-            randint(0, 9999999999),
+            randint(0, 2**32-1),
         )
         self.eval_random_states = TPOTPipeline.use_first(
             eval_random_states,

--- a/liger/pipelines/tpot.py
+++ b/liger/pipelines/tpot.py
@@ -47,8 +47,8 @@ REG_CLASS_OVERLAP = {
     "sklearn.feature_selection.SelectFromModel",
 }
 PIPELINE_PARAM_KEYS = {
-    "config_name",
-    "data_name",
+    "config_file",
+    "data_file",
     "regression",
     "target_gens",
     "eval_random_states",
@@ -104,9 +104,10 @@ class TPOTPipeline:
         slurm_id: int | None = None,
         id: str | None = None,
     ) -> None:
-        self.config_name = TPOTPipeline.get_filename(config_file)
-        self.dataset = Dataset.from_csv(data_file)
+        self.config_file = config_file
+        self.data_file = data_file
         self.data_name = TPOTPipeline.get_filename(data_file)
+        self.dataset = Dataset.from_csv(data_file)
         self.complete_gens = 0
         self.slurm_id = slurm_id
 
@@ -138,7 +139,7 @@ class TPOTPipeline:
             config_dict = regressor_config_dict
             self.regression = True
         else:
-            raise TypeError(f"\"config_dict\" field of {self.config_name} is not None or of type dict")
+            raise TypeError(f"\"config_dict\" field of {self.config_file} is not None or of type dict")
 
         # Set parameters
         self.target_gens = TPOTPipeline.use_first(
@@ -283,9 +284,9 @@ class TPOTPipeline:
             else:
                 raise KeyError(f"{key} is not a valid sklearn model")
         if clas_key and require_regression:
-            raise TypeError(f"float values found in {self.data_name}, but {self.config_name} contains classifiers")
+            raise TypeError(f"float values found in {self.data_name}, but {self.config_file} contains classifiers")
         if reg_key and clas_key:
-            raise ValueError(f"{self.config_name} contains regressors and classifiers")
+            raise ValueError(f"{self.config_file} contains regressors and classifiers")
         return not clas_key
 
 

--- a/liger/pipelines/tpot.py
+++ b/liger/pipelines/tpot.py
@@ -345,16 +345,17 @@ class TPOTPipeline:
 
 
     def evaluate(self) -> None:
-        training_score = self.tpot.score(self.dataset.X, self.dataset.y)
+        # training_score = self.tpot.score(self.dataset.X, self.dataset.y)
         scores = {}
         ratings = {}
         for eval_random_state in self.eval_random_states:
             kfold_predictions, kfold_r2 = self.tpot_test(eval_random_state)
             scores[eval_random_state] = kfold_r2
             ratings[eval_random_state] = kfold_predictions
+        print("RATINGS\n", ratings)
         pipeline_parameters = {key: value for key, value in self.__dict__.items() if key in PIPELINE_PARAM_KEYS}
         tpot_parameters = {key: value for key, value in self.tpot.__dict__.items() if key in TPOT_PARAM_KEYS}
-        pipeline_attributes = {"scores": scores, "ratings": ratings}
+        pipeline_attributes = {"kfold_scores": scores, "kfold_ratings": ratings}
         tpot_attributes = {key: value for key, value in self.tpot.__dict__.items() if key in TPOT_ATTR_KEYS}
         pipeline_dict = {
             "pipeline_parameters": pipeline_parameters,

--- a/liger/run_tpot_pipeline.py
+++ b/liger/run_tpot_pipeline.py
@@ -5,7 +5,7 @@ from liger.pipelines.tpot import TPOTPipeline
 def main():
     args = get_args()
 
-    data_name = TPOTPipeline.get_data_name(args.data)
+    data_name = TPOTPipeline.get_filename(args.data)
     id = TPOTPipeline.get_id(args.ngens, args.popsize, args.tpotrs, args.regression, args.notrees, args.noxg)
     pickle_file = TPOTPipeline.find_pickle(data_name, id)
     if pickle_file:

--- a/liger/run_tpot_pipeline.py
+++ b/liger/run_tpot_pipeline.py
@@ -6,12 +6,17 @@ def main():
     args = get_args()
 
     data_name = TPOTPipeline.get_filename(args.data)
-    id = TPOTPipeline.get_id(args.ngens, args.popsize, args.tpotrs, args.regression, args.notrees, args.noxg)
-    pickle_file = TPOTPipeline.find_pickle(data_name, id)
-    if pickle_file:
+    if args.id.lower in {"", "none"}:
+        id = None
+    else:
+        id = args.id
+    pickle_file = None
+    if id is not None:
+        pickle_file = TPOTPipeline.find_pickle(data_name, args.id)
+    if pickle_file is not None:
         pipeline = TPOTPipeline.from_pickle(pickle_file)
     else:
-        if args.sevalrs is None or args.nevalrs is None:
+        if args.nevalrs is None:
             eval_random_states = None
         else:
             eval_random_states = [i+args.sevalrs for i in range(args.nevalrs)]
@@ -25,7 +30,7 @@ def main():
             max_time_mins=args.maxtime,
             n_splits=args.nsplits,
             slurm_id=args.slurmid,
-            id=args.id,
+            id=id,
         )
     pipeline.run_1_gen()
 
@@ -69,7 +74,7 @@ def get_args() -> Namespace:
         "--sevalrs",
         type=int,
         required=False,
-        default=None,
+        default=0,
         help="eval random state start"
     )
     parser.add_argument(

--- a/liger/run_tpot_pipeline.py
+++ b/liger/run_tpot_pipeline.py
@@ -11,18 +11,21 @@ def main():
     if pickle_file:
         pipeline = TPOTPipeline.from_pickle(pickle_file)
     else:
+        if args.sevalrs is None or args.nevalrs is None:
+            eval_random_states = None
+        else:
+            eval_random_states = [i+args.sevalrs for i in range(args.nevalrs)]
         pipeline = TPOTPipeline(
-            args.data,
-            args.regression,
-            args.ngens,
-            args.popsize,
-            args.tpotrs,
-            [i+args.sevalrs for i in range(args.nevalrs)],
-            args.notrees,
-            args.noxg,
-            args.cutoffmins,
-            args.nsplits,
-            args.slurmid,
+            config_file=args.config,
+            data_file=args.data,
+            target_gens=args.ngens,
+            population_size=args.popsize,
+            tpot_random_state=args.tpotrs,
+            eval_random_states=eval_random_states,
+            max_time_mins=args.maxtime,
+            n_splits=args.nsplits,
+            slurm_id=args.slurmid,
+            id=args.id,
         )
     pipeline.run_1_gen()
 
@@ -30,66 +33,54 @@ def main():
 def get_args() -> Namespace:
     parser = ArgumentParser(description="Script that runs tpot fitting and evaluation")
     parser.add_argument(
+        "--config",
+        type=str,
+        required=True,
+        help="config file path"
+    )       #e.g., "Configs/nolong_reg_1.json"
+    parser.add_argument(
         "--data",
         type=str,
         required=True,
         help="training data file path"
     )       #e.g., "Data/human_size_rating_1_1.csv"
     parser.add_argument(
-        "--regression",
-        action="store_true",
-        dest="regression",
-        help="run regression (not classification)"
-    )
-    parser.add_argument(
         "--ngens",
         type=int,
         required=False,
-        default=5,
+        default=None,
         help="number of tpot fitting generations"
     )
     parser.add_argument(
         "--popsize",
         type=int,
         required=False,
-        default=50,
+        default=None,
         help="tpot fitting population size"
     )
     parser.add_argument(
         "--tpotrs",
         type=int,
         required=False,
-        default=0,
+        default=None,
         help="tpot random state"
     )
     parser.add_argument(
         "--sevalrs",
         type=int,
         required=False,
-        default=0,
+        default=None,
         help="eval random state start"
     )
     parser.add_argument(
         "--nevalrs",
         type=int,
         required=False,
-        default=1,
+        default=None,
         help="number of eval random states to test"
     )
     parser.add_argument(
-        "--notrees",
-        action="store_true",
-        dest="notrees",
-        help="whether RandomForest and Tree models should be excluded"
-    )
-    parser.add_argument(
-        "--noxg",
-        action="store_true",
-        dest="noxg",
-        help="whether XGBoost models should be excluded"
-    )
-    parser.add_argument(
-        "--cutoffmins",
+        "--maxtime",
         type=int,
         required=False,
         default=None,
@@ -108,6 +99,13 @@ def get_args() -> Namespace:
         required=False,
         default=None,
         help="$SLURM_JOB_ID, if applicable"
+    )
+    parser.add_argument(
+        "--id",
+        type=str,
+        required=False,
+        default=None,
+        help="ID of the job - used for all output files"
     )
     return parser.parse_args()
 

--- a/liger/run_tpot_pipeline.py
+++ b/liger/run_tpot_pipeline.py
@@ -6,7 +6,7 @@ def main():
     args = get_args()
 
     data_name = TPOTPipeline.get_filename(args.data)
-    if args.id.lower in {"", "none"}:
+    if str(args.id).lower() in {"", "none"}:
         id = None
     else:
         id = args.id


### PR DESCRIPTION
This revolutionizes the input to and output from TPOT pipelines, allowing (hopefully) all potentially relevant parameters to be passed in and attributes to be returned out.

Now config JSON files (By default stored in the `Config/`) directory determine the parameters passed to `TPOTPipeline` objects, though some parameters passed via the command line can override config file parameters.

`performance.csv` and `ratings.csv` are no longer output, their content instead packaged into the output JSON file.

Output JSON files can be used as config files for other runs.

---

This change disables some of the workflow surrounding the `performance.csv` and `ratings.csv` files (the code for which was not contained in this repository anyways) - data extraction functions will be added in the future.